### PR TITLE
feat: file-level hot/standard storage class

### DIFF
--- a/api/storage/tx_api.go
+++ b/api/storage/tx_api.go
@@ -79,6 +79,8 @@ func getStorageTx(c *gin.Context) (interface{}, error) {
 		TxHash:      submit.TxHash,
 		Timestamp:   submitTime,
 		Expiration:  submitTime + expireSeconds.Uint64(),
+
+		StorageClass: normalizeStorageClass(submit.StorageClass),
 	}
 
 	var extra store.SubmitExtra
@@ -154,8 +156,8 @@ func listAddressStorageTxs(c *gin.Context) (interface{}, error) {
 func listSubmits(addressID *uint64, params listStorageTxParam) (int64,
 	[]store.Submit, error) {
 	if addressID == nil {
-		total, submits, err := db.SubmitStore.List(params.RootHash, params.TxHash, params.isDesc(), params.Skip,
-			params.Limit)
+		total, submits, err := db.SubmitStore.List(params.RootHash, params.TxHash, params.StorageClass,
+			params.isDesc(), params.Skip, params.Limit)
 		if err != nil {
 			return 0, nil, scanApi.ErrDatabase(errors.WithMessage(err, "Failed to get submit list"))
 		}
@@ -163,7 +165,7 @@ func listSubmits(addressID *uint64, params listStorageTxParam) (int64,
 	}
 
 	total, addrSubmits, err := db.AddressSubmitStore.List(addressID, params.RootHash, params.TxHash,
-		params.MinTimestamp, params.MaxTimestamp, params.isDesc(), params.Skip, params.Limit)
+		params.StorageClass, params.MinTimestamp, params.MaxTimestamp, params.isDesc(), params.Skip, params.Limit)
 	if err != nil {
 		return 0, nil, scanApi.ErrDatabase(errors.WithMessage(err, "Failed to get account's submit list"))
 	}
@@ -182,6 +184,7 @@ func listSubmits(addressID *uint64, params listStorageTxParam) (int64,
 			TotalSegNum:     as.TotalSegNum,
 			UploadedSegNum:  as.UploadedSegNum,
 			Fee:             as.Fee,
+			StorageClass:    as.StorageClass,
 		})
 	}
 
@@ -219,6 +222,7 @@ func convertStorageTxs(total int64, submits []store.Submit) (*StorageTxList, err
 			Expiration:       submitTime + expireSeconds.Uint64(),
 			DataSize:         submit.Length,
 			StorageFee:       submit.Fee,
+			StorageClass:     normalizeStorageClass(submit.StorageClass),
 		}
 		storageTxs = append(storageTxs, storageTx)
 	}
@@ -255,4 +259,14 @@ func refreshFileInfos(submits []store.Submit) ([]store.Submit, error) {
 	}
 
 	return submits, nil
+}
+
+// normalizeStorageClass returns the storage class for API responses, defaulting
+// to "standard" when unset (e.g. legacy rows the reconcile worker has not yet
+// classified).
+func normalizeStorageClass(class string) string {
+	if class == "" {
+		return store.StorageClassStandard
+	}
+	return class
 }

--- a/api/storage/tx_api_test.go
+++ b/api/storage/tx_api_test.go
@@ -1,0 +1,16 @@
+package storage
+
+import "testing"
+
+func TestNormalizeStorageClass(t *testing.T) {
+	cases := map[string]string{
+		"":         "standard", // unclassified rows default to standard
+		"hot":      "hot",
+		"standard": "standard",
+	}
+	for in, want := range cases {
+		if got := normalizeStorageClass(in); got != want {
+			t.Errorf("normalizeStorageClass(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/api/storage/types.go
+++ b/api/storage/types.go
@@ -21,6 +21,7 @@ type listStorageTxParam struct {
 	PageParam
 	RootHash     *string `form:"rootHash" binding:"omitempty"`
 	TxHash       *string `form:"txHash" binding:"omitempty"`
+	StorageClass *string `form:"storageClass" binding:"omitempty,oneof=hot standard"`
 	MinTimestamp *int    `form:"minTimestamp" binding:"omitempty,number"`
 	MaxTimestamp *int    `form:"maxTimestamp" binding:"omitempty,number"`
 }
@@ -206,6 +207,8 @@ type StorageTxInfo struct {
 
 	Segments         uint64 `json:"segments"`         // The total number of segments the file is split into
 	UploadedSegments uint64 `json:"uploadedSegments"` // The number of segments the file has been uploaded
+
+	StorageClass string `json:"storageClass"` // Storage class: "hot" (cached on a hot-storage provider) or "standard"
 }
 
 // StorageTxDetail model info
@@ -233,6 +236,8 @@ type StorageTxDetail struct {
 	GasFee   uint64 `json:"gasFee"`   // The gas fee of the transaction on layer1
 	GasUsed  uint64 `json:"gasUsed"`  // The gas used of the transaction on layer1
 	GasLimit uint64 `json:"gasLimit"` // The gas limit of the transaction on layer1
+
+	StorageClass string `json:"storageClass"` // Storage class: "hot" (cached on a hot-storage provider) or "standard"
 }
 
 // AccountStats model info

--- a/config/config.yml
+++ b/config/config.yml
@@ -35,6 +35,13 @@ eth:
 #    remind: 5m
 #  # Alert channel
 #  alertChannel: tgRobot
+#  # Hot-storage router base URL. When set, the reconcile worker labels files
+#  # hot/standard by paging the router's cached-file set. Leave empty to disable.
+#  hotRouter: https://hot-router.0g.ai
+#  # How often to reconcile the hot/standard storage class (default 2m)
+#  classReconcileInterval: 2m
+#  # Page size when paging GET /files/cached (default 2000)
+#  classPageLimit: 2000
 
 # storage contracts info configurations
 contract:

--- a/rpc/storage.go
+++ b/rpc/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/0glabs/0g-storage-client/node"
@@ -43,6 +44,14 @@ type StorageConfig struct {
 	AlertChannel          string
 	HealthReport          health.TimedCounterConfig
 	SyncGapAlertThreshold uint64 `default:"1000"`
+
+	// HotRouter is the base URL of the hot-storage router. When empty, the
+	// storage-class reconcile worker is disabled and all files stay "standard".
+	HotRouter string
+	// ClassReconcileInterval is how often the worker reconciles the hot set.
+	ClassReconcileInterval time.Duration `default:"2m"`
+	// ClassPageLimit is the page size used when paging GET /files/cached.
+	ClassPageLimit int `default:"2000"`
 }
 
 type FileInfoParam struct {
@@ -162,6 +171,41 @@ func GetNodeStatus(storageConfig StorageConfig) (*node.Status, error) {
 	}
 
 	return &status, nil
+}
+
+// CachedFilesResponse is the body of the hot router's GET /files/cached.
+type CachedFilesResponse struct {
+	Hashes     []string `json:"hashes"`
+	NextCursor string   `json:"next_cursor"`
+}
+
+// ListCachedFiles fetches one page of the hot router's cached-file set (the hot
+// set), keyset-paginated by file hash. Pass an empty cursor to start; an empty
+// returned nextCursor means there are no more pages. The router returns a plain
+// JSON body (not the indexer's BusinessError envelope), so this does not reuse
+// requestIndexer.
+func ListCachedFiles(cfg StorageConfig, cursor string, limit int) (hashes []string, nextCursor string, err error) {
+	url := fmt.Sprintf("%s/files/cached?limit=%d", strings.TrimRight(cfg.HotRouter, "/"), limit)
+	if cursor != "" {
+		url += "&cursor=" + cursor
+	}
+
+	client := resty.New()
+	if cfg.RequestTimeout > 0 {
+		client.SetTimeout(cfg.RequestTimeout)
+	}
+
+	var result CachedFilesResponse
+	resp, err := client.R().SetResult(&result).Get(url)
+	if err != nil {
+		return nil, "", errors.WithMessagef(err, "Failed to request hot router, %s", url)
+	}
+	if resp.IsError() {
+		return nil, "", errors.Errorf("Failed to request hot router, %s status %s body %s",
+			url, resp.Status(), resp.String())
+	}
+
+	return result.Hashes, result.NextCursor, nil
 }
 
 func requestIndexer(url string) ([]byte, error) {

--- a/rpc/storage_test.go
+++ b/rpc/storage_test.go
@@ -1,0 +1,74 @@
+package rpc
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestListCachedFiles_PagesAndParsesParams(t *testing.T) {
+	var gotPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			io.WriteString(w, `{"hashes":["0x01","0x02"],"next_cursor":"0x02"}`)
+			return
+		}
+		io.WriteString(w, `{"hashes":["0x03"],"next_cursor":""}`)
+	}))
+	defer srv.Close()
+
+	cfg := StorageConfig{HotRouter: srv.URL}
+
+	hashes, next, err := ListCachedFiles(cfg, "", 2)
+	if err != nil {
+		t.Fatalf("page1: unexpected error: %v", err)
+	}
+	if next != "0x02" {
+		t.Fatalf("page1 nextCursor = %q, want 0x02", next)
+	}
+	if len(hashes) != 2 || hashes[0] != "0x01" || hashes[1] != "0x02" {
+		t.Fatalf("page1 hashes = %v, want [0x01 0x02]", hashes)
+	}
+
+	hashes2, next2, err := ListCachedFiles(cfg, next, 2)
+	if err != nil {
+		t.Fatalf("page2: unexpected error: %v", err)
+	}
+	if next2 != "" {
+		t.Fatalf("page2 nextCursor = %q, want empty", next2)
+	}
+	if len(hashes2) != 1 || hashes2[0] != "0x03" {
+		t.Fatalf("page2 hashes = %v, want [0x03]", hashes2)
+	}
+
+	// Verify outgoing query params: limit on both pages, cursor only on the second.
+	if len(gotPaths) != 2 {
+		t.Fatalf("server saw %d requests, want 2", len(gotPaths))
+	}
+	q0, _ := url.Parse(gotPaths[0])
+	if got := q0.Query().Get("limit"); got != "2" {
+		t.Errorf("page1 limit = %q, want 2", got)
+	}
+	if _, ok := q0.Query()["cursor"]; ok {
+		t.Errorf("page1 should not send a cursor, got path %q", gotPaths[0])
+	}
+	q1, _ := url.Parse(gotPaths[1])
+	if got := q1.Query().Get("cursor"); got != "0x02" {
+		t.Errorf("page2 cursor = %q, want 0x02", got)
+	}
+}
+
+func TestListCachedFiles_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if _, _, err := ListCachedFiles(StorageConfig{HotRouter: srv.URL}, "", 10); err == nil {
+		t.Fatal("expected an error on a 500 response, got nil")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -382,6 +382,12 @@ func TxHash(rh string) func(db *gorm.DB) *gorm.DB {
 	}
 }
 
+func StorageClass(class string) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("storage_class = ?", class)
+	}
+}
+
 func StatType(t string) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("stat_type = ?", t)

--- a/store/store_address_submit.go
+++ b/store/store_address_submit.go
@@ -23,6 +23,9 @@ type AddressSubmit struct {
 	UploadedSegNum uint64          `gorm:"not null;default:0"`
 	Status         uint8           `gorm:"not null;default:0"`
 	Fee            decimal.Decimal `gorm:"type:decimal(65);not null"`
+
+	// StorageClass mirrors Submit.StorageClass for per-address (My Files) queries.
+	StorageClass string `gorm:"size:20;not null;default:standard;index"`
 }
 
 func (AddressSubmit) TableName() string {
@@ -61,8 +64,21 @@ func (ass *AddressSubmitStore) UpdateByPrimaryKey(dbTx *gorm.DB, s *AddressSubmi
 	return nil
 }
 
-func (ass *AddressSubmitStore) List(addressID *uint64, rootHash *string, txHash *string, minTimestamp, maxTimestamp *int,
-	idDesc bool, skip, limit int) (
+// SetStorageClassByRootHashes mirrors SubmitStore.SetStorageClassByRootHashes
+// for the per-address table so My Files stays consistent with the global view.
+func (ass *AddressSubmitStore) SetStorageClassByRootHashes(class string, rootHashes []string) (int64, error) {
+	if len(rootHashes) == 0 {
+		return 0, nil
+	}
+	res := ass.DB.Model(&AddressSubmit{}).
+		Where("root_hash IN ?", rootHashes).
+		Where("storage_class <> ?", class).
+		Update("storage_class", class)
+	return res.RowsAffected, res.Error
+}
+
+func (ass *AddressSubmitStore) List(addressID *uint64, rootHash *string, txHash *string, storageClass *string,
+	minTimestamp, maxTimestamp *int, idDesc bool, skip, limit int) (
 	int64, []AddressSubmit, error) {
 	if addressID == nil {
 		return 0, nil, errors.New("nil addressID")
@@ -76,6 +92,9 @@ func (ass *AddressSubmitStore) List(addressID *uint64, rootHash *string, txHash 
 	}
 	if txHash != nil {
 		conds = append(conds, TxHash(*txHash))
+	}
+	if storageClass != nil {
+		conds = append(conds, StorageClass(*storageClass))
 	}
 	if minTimestamp != nil {
 		conds = append(conds, MinTimestampBlockTime(*minTimestamp))

--- a/store/store_submit.go
+++ b/store/store_submit.go
@@ -22,6 +22,14 @@ const (
 	submitPartitionSize = 10_000_000
 )
 
+// Storage class values for the storage_class column. A file is "hot" when it is
+// currently cached on a hot-storage provider (per the hot router), "standard"
+// otherwise (the default — it lives only on the base storage network).
+const (
+	StorageClassStandard = "standard"
+	StorageClassHot      = "hot"
+)
+
 type Submit struct {
 	SubmissionIndex uint64 `gorm:"primaryKey;autoIncrement:false"`
 	RootHash        string `gorm:"size:66;index:idx_root"`
@@ -37,6 +45,11 @@ type Submit struct {
 	UploadedSegNum uint64          `gorm:"not null;default:0"`
 	Status         uint8           `gorm:"not null;default:0"`
 	Fee            decimal.Decimal `gorm:"type:decimal(65);not null"`
+
+	// StorageClass is "hot" if the file is currently cached on a hot-storage
+	// provider, "standard" otherwise. Defaults to "standard" at insert time and is
+	// maintained by the storage-class reconcile worker.
+	StorageClass string `gorm:"size:20;not null;default:standard;index"`
 
 	Extra []byte `gorm:"type:mediumText"` // json field
 }
@@ -194,7 +207,34 @@ func (ss *SubmitStore) UpdateByPrimaryKeys(dbTx *gorm.DB, s *Submit, submissionI
 	return nil
 }
 
-func (ss *SubmitStore) List(rootHash *string, txHash *string, idDesc bool, skip, limit int) (int64, []Submit, error) {
+// SetStorageClassByRootHashes sets storage_class=class for the submits whose
+// root hash is in rootHashes and whose class currently differs. The "currently
+// differs" guard keeps steady-state reconcile cycles near-zero-write. Returns
+// the number of rows updated.
+func (ss *SubmitStore) SetStorageClassByRootHashes(class string, rootHashes []string) (int64, error) {
+	if len(rootHashes) == 0 {
+		return 0, nil
+	}
+	res := ss.DB.Model(&Submit{}).
+		Where("root_hash IN ?", rootHashes).
+		Where("storage_class <> ?", class).
+		Update("storage_class", class)
+	return res.RowsAffected, res.Error
+}
+
+// ListHotRootHashes returns the root hashes of all submits currently marked hot.
+// Used by the reconcile worker to find files that were evicted from the hot tier
+// (currently hot in the DB but absent from the router's hot set) so they can be
+// demoted back to standard.
+func (ss *SubmitStore) ListHotRootHashes() ([]string, error) {
+	var rootHashes []string
+	err := ss.DB.Model(&Submit{}).
+		Where("storage_class = ?", StorageClassHot).
+		Pluck("root_hash", &rootHashes).Error
+	return rootHashes, err
+}
+
+func (ss *SubmitStore) List(rootHash *string, txHash *string, storageClass *string, idDesc bool, skip, limit int) (int64, []Submit, error) {
 	dbRaw := ss.DB.Model(&Submit{})
 	var conds []func(db *gorm.DB) *gorm.DB
 	if rootHash != nil {
@@ -202,6 +242,9 @@ func (ss *SubmitStore) List(rootHash *string, txHash *string, idDesc bool, skip,
 	}
 	if txHash != nil {
 		conds = append(conds, TxHash(*txHash))
+	}
+	if storageClass != nil {
+		conds = append(conds, StorageClass(*storageClass))
 	}
 	dbRaw.Scopes(conds...)
 

--- a/sync/storage.go
+++ b/sync/storage.go
@@ -116,6 +116,113 @@ func (ss *StorageSyncer) NodeSyncHeight(ctx context.Context, ticker *time.Ticker
 	}
 }
 
+// ReconcileStorageClass refreshes each file's hot/standard storage class by
+// reconciling against the hot router's current cache set (the "hot set"). Every
+// file defaults to "standard"; this worker promotes files present in the hot set
+// to "hot" and demotes files that have been evicted (currently "hot" in the DB
+// but no longer in the hot set) back to "standard". It is the source of truth for
+// the label and self-heals after chain reorgs, missed events, and the
+// cache-before-index race. When no hot router is configured it is a no-op.
+func (ss *StorageSyncer) ReconcileStorageClass(ctx context.Context, ticker *time.Ticker) {
+	if interrupted(ctx) {
+		return
+	}
+
+	cfg := ss.storageConfig
+	if cfg.HotRouter == "" {
+		// Feature disabled; idle on a slow tick so we don't spin at intervalNormal.
+		ticker.Reset(time.Minute)
+		return
+	}
+
+	interval := cfg.ClassReconcileInterval
+	if interval <= 0 {
+		interval = 2 * time.Minute
+	}
+	limit := cfg.ClassPageLimit
+	if limit <= 0 {
+		limit = 2000
+	}
+
+	// 1. Page the router's full hot set. On any error, skip this cycle WITHOUT
+	//    demoting — a transient router outage must not mass-flip files to standard.
+	hotSet := make(map[string]struct{})
+	cursor := ""
+	for {
+		hashes, next, err := rpc.ListCachedFiles(cfg, cursor, limit)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to fetch hot set from router; skipping storage-class reconcile")
+			ticker.Reset(intervalException)
+			return
+		}
+		for _, h := range hashes {
+			hotSet[strings.ToLower(h)] = struct{}{}
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+
+	// 2. Promote files in the hot set to "hot" (the <> guard makes this near-zero-write
+	//    in steady state).
+	hotList := make([]string, 0, len(hotSet))
+	for h := range hotSet {
+		hotList = append(hotList, h)
+	}
+	if err := ss.setStorageClassChunked(store.StorageClassHot, hotList); err != nil {
+		logrus.WithError(err).Error("Failed to promote files to storage_class=hot")
+		ticker.Reset(intervalException)
+		return
+	}
+
+	// 3. Demote evicted files: currently "hot" in the DB but absent from the hot set.
+	currentHot, err := ss.db.SubmitStore.ListHotRootHashes()
+	if err != nil {
+		logrus.WithError(err).Error("Failed to list currently-hot files for demotion")
+		ticker.Reset(intervalException)
+		return
+	}
+	toDemote := make([]string, 0)
+	for _, h := range currentHot {
+		if _, ok := hotSet[strings.ToLower(h)]; !ok {
+			toDemote = append(toDemote, h)
+		}
+	}
+	if err := ss.setStorageClassChunked(store.StorageClassStandard, toDemote); err != nil {
+		logrus.WithError(err).Error("Failed to demote evicted files to storage_class=standard")
+		ticker.Reset(intervalException)
+		return
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"hotSet":  len(hotList),
+		"demoted": len(toDemote),
+	}).Debug("Reconciled storage class")
+
+	ticker.Reset(interval)
+}
+
+// setStorageClassChunked updates storage_class for the given root hashes in both
+// the submits and address_submits tables, in bounded IN-list chunks.
+func (ss *StorageSyncer) setStorageClassChunked(class string, rootHashes []string) error {
+	const chunkSize = 1000
+	for i := 0; i < len(rootHashes); i += chunkSize {
+		end := i + chunkSize
+		if end > len(rootHashes) {
+			end = len(rootHashes)
+		}
+		batch := rootHashes[i:end]
+		if _, err := ss.db.SubmitStore.SetStorageClassByRootHashes(class, batch); err != nil {
+			return err
+		}
+		if _, err := ss.db.AddressSubmitStore.SetStorageClassByRootHashes(class, batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // checkSyncHeightGaps monitors sync height differences and returns error if gaps exceed 1000 blocks
 func (ss *StorageSyncer) checkSyncHeightGaps(nodeSyncHeight uint64) error {
 	if ss.blockchainClient == nil {

--- a/sync/storage_class_integration_test.go
+++ b/sync/storage_class_integration_test.go
@@ -1,0 +1,204 @@
+//go:build integration
+
+// MySQL-backed integration test for the storage-class reconcile worker.
+//
+// Run against a throwaway MySQL (defaults match the docker container started by
+// the test runner):
+//
+//	docker run -d --name scan-it-mysql -e MYSQL_ROOT_PASSWORD=root \
+//	    -e MYSQL_DATABASE=scan_it_test -p 3380:3306 mysql:8
+//	go test -tags integration ./sync/ -run TestReconcileStorageClass -v
+//
+// Override via MYSQL_HOST / MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE.
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0glabs/0g-storage-scan/rpc"
+	"github.com/0glabs/0g-storage-scan/store"
+	"github.com/Conflux-Chain/go-conflux-util/health"
+	cfxmysql "github.com/Conflux-Chain/go-conflux-util/store/mysql"
+	"github.com/shopspring/decimal"
+)
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func mustTestStore(t *testing.T) *store.MysqlStore {
+	t.Helper()
+	cfg := cfxmysql.Config{
+		Host:            envOr("MYSQL_HOST", "127.0.0.1:3380"),
+		Username:        envOr("MYSQL_USER", "root"),
+		Password:        envOr("MYSQL_PASSWORD", "root"),
+		Database:        envOr("MYSQL_DATABASE", "scan_it_test"),
+		ConnMaxLifetime: 3 * time.Minute,
+		MaxOpenConns:    10,
+		MaxIdleConns:    10,
+		LogLevel:        "error",
+		SlowThreshold:   200 * time.Millisecond,
+	}
+	db := cfg.MustOpenOrCreate(&store.Submit{}, &store.AddressSubmit{})
+	// Exercise the production migration path (AutoMigrate adds the storage_class
+	// column to a pre-existing table) and start from a clean slate.
+	if err := db.AutoMigrate(&store.Submit{}, &store.AddressSubmit{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	db.Exec("DELETE FROM submits")
+	db.Exec("DELETE FROM address_submits")
+	return store.MustNewStore(db, cfg)
+}
+
+func seedFile(t *testing.T, st *store.MysqlStore, idx uint64, root string) {
+	t.Helper()
+	txHash := fmt.Sprintf("0x%064x", idx)
+	now := time.Now()
+	// StorageClass intentionally left unset to verify the column default applies.
+	if err := st.DB.Create(&store.Submit{
+		SubmissionIndex: idx, RootHash: root, SenderID: 1, Length: 100,
+		BlockNumber: idx, BlockTime: now, TxHash: txHash, Fee: decimal.Zero,
+	}).Error; err != nil {
+		t.Fatalf("seed submit %d: %v", idx, err)
+	}
+	if err := st.DB.Create(&store.AddressSubmit{
+		SenderID: 1, SubmissionIndex: idx, RootHash: root, Length: 100,
+		BlockNumber: idx, BlockTime: now, TxHash: txHash, Fee: decimal.Zero,
+	}).Error; err != nil {
+		t.Fatalf("seed address_submit %d: %v", idx, err)
+	}
+}
+
+func classOf(t *testing.T, st *store.MysqlStore, idx uint64) (string, string) {
+	t.Helper()
+	var s store.Submit
+	if err := st.DB.First(&s, "submission_index = ?", idx).Error; err != nil {
+		t.Fatalf("read submit %d: %v", idx, err)
+	}
+	var as store.AddressSubmit
+	if err := st.DB.First(&as, "submission_index = ?", idx).Error; err != nil {
+		t.Fatalf("read address_submit %d: %v", idx, err)
+	}
+	return s.StorageClass, as.StorageClass
+}
+
+// fakeRouter serves GET /files/cached with real keyset pagination over the given
+// hot set, mirroring the production router so the worker's paging loop is exercised.
+func fakeRouter(hot *[]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		set := append([]string(nil), (*hot)...)
+		sort.Strings(set)
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		if limit <= 0 {
+			limit = 2000
+		}
+		cursor := r.URL.Query().Get("cursor")
+		out := make([]string, 0, limit)
+		for _, h := range set {
+			if cursor == "" || h > cursor {
+				out = append(out, h)
+				if len(out) == limit {
+					break
+				}
+			}
+		}
+		next := ""
+		if len(out) == limit {
+			next = out[len(out)-1]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"hashes": out, "next_cursor": next})
+	}))
+}
+
+func TestReconcileStorageClass(t *testing.T) {
+	st := mustTestStore(t)
+
+	rootA := "0x" + strings.Repeat("a", 64) // will be hot
+	rootB := "0x" + strings.Repeat("b", 64) // stays standard
+	rootC := "0x" + strings.Repeat("c", 64) // hot, then evicted
+	seedFile(t, st, 1, rootA)
+	seedFile(t, st, 2, rootB)
+	seedFile(t, st, 3, rootC)
+
+	// Newly-inserted rows must default to standard (column default).
+	if c, ac := classOf(t, st, 1); c != "standard" || ac != "standard" {
+		t.Fatalf("default class = (%q,%q), want (standard,standard)", c, ac)
+	}
+
+	hot := []string{rootA, rootC}
+	srv := fakeRouter(&hot)
+	defer srv.Close()
+
+	// ClassPageLimit=1 forces multi-page keyset pagination through the worker loop.
+	ss := MustNewStorageSyncer(st, rpc.StorageConfig{
+		HotRouter:      srv.URL,
+		ClassPageLimit: 1,
+		RequestTimeout: 3 * time.Second,
+	}, "", health.TimedCounterConfig{}, nil)
+
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	ctx := context.Background()
+
+	// First reconcile: A and C become hot, B stays standard — in both tables.
+	ss.ReconcileStorageClass(ctx, ticker)
+	assertClass(t, st, 1, "hot")
+	assertClass(t, st, 2, "standard")
+	assertClass(t, st, 3, "hot")
+
+	// Evict C from the hot set; next reconcile must demote C, keep A hot.
+	hot = []string{rootA}
+	ss.ReconcileStorageClass(ctx, ticker)
+	assertClass(t, st, 1, "hot")
+	assertClass(t, st, 2, "standard")
+	assertClass(t, st, 3, "standard")
+}
+
+func assertClass(t *testing.T, st *store.MysqlStore, idx uint64, want string) {
+	t.Helper()
+	c, ac := classOf(t, st, idx)
+	if c != want {
+		t.Errorf("submit %d storage_class = %q, want %q", idx, c, want)
+	}
+	if ac != want {
+		t.Errorf("address_submit %d storage_class = %q, want %q (My Files must stay consistent)", idx, ac, want)
+	}
+}
+
+// TestReconcileStorageClass_RouterDownNoDemote verifies a router outage never
+// mass-flips already-hot files back to standard.
+func TestReconcileStorageClass_RouterDownNoDemote(t *testing.T) {
+	st := mustTestStore(t)
+	rootA := "0x" + strings.Repeat("a", 64)
+	seedFile(t, st, 1, rootA)
+
+	hot := []string{rootA}
+	srv := fakeRouter(&hot)
+	ss := MustNewStorageSyncer(st, rpc.StorageConfig{HotRouter: srv.URL, ClassPageLimit: 10}, "",
+		health.TimedCounterConfig{}, nil)
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	ctx := context.Background()
+
+	ss.ReconcileStorageClass(ctx, ticker)
+	assertClass(t, st, 1, "hot")
+
+	// Router goes down: point at a closed server. The hot file must remain hot.
+	srv.Close()
+	ss.ReconcileStorageClass(ctx, ticker)
+	assertClass(t, st, 1, "hot")
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -97,6 +97,7 @@ func (s *Syncer) Sync(ctx context.Context, wg *sync.WaitGroup) {
 
 	go s.storageSyncer.Sync(ctx, s.storageSyncer.LatestFiles)
 	go s.storageSyncer.Sync(ctx, s.storageSyncer.NodeSyncHeight)
+	go s.storageSyncer.Sync(ctx, s.storageSyncer.ReconcileStorageClass)
 	go s.patchSyncer.Sync(ctx, s.patchSyncer.L1Txs)
 	go s.patchSyncer.Sync(ctx, s.patchSyncer.MinerAttempts)
 


### PR DESCRIPTION
## What

Adds a file-level **hot / standard** storage class to the explorer backend.

- **Model**: `storage_class` on `Submit` + `AddressSubmit` (GORM auto-migrate; `default:standard`, indexed). Existing rows backfill to `standard` for free — no historical router calls.
- **Reconcile worker** (`sync`): pages the hot router's `GET /files/cached`, promotes cached files → `hot`, demotes evicted files → `standard`. Self-heals after reorgs / missed events / the cache-before-index race. **Never demotes on a router outage.** Disabled when `storage.hotRouter` is unset.
- **API**: `storageClass` on `StorageTxInfo` + `StorageTxDetail` (defaults to `standard`); `?storageClass=hot|standard` filter on the file list + account file list — covers Files filter, File Detail, My Files, Recent Submissions.
- **rpc**: `ListCachedFiles(cursor, limit)` client.

Requires the companion hot-router endpoint: `GET /files/cached` (0gfoundation/0g-hot-storage PR).

## Why pull-reconcile (not push / direct DB write)

Only pull-reconcile self-heals after chain reorgs — scan deletes & re-inserts `submits` rows on reorg, which would silently wipe any externally-written class — and after missed events / the cache-before-index race. The router never touches scan's DB. Full rationale in #32.

## Tests

- **Unit**: rpc client (httptest), `normalizeStorageClass`.
- **Integration** (`go test -tags integration ./sync/`, MySQL-backed): migration default, promote, multi-page keyset paging, demote-on-eviction, My Files (`address_submits`) mirroring, outage-no-demote. **PASS.**
- `go build` / `go vet` / `gofmt` clean. Default `go test ./...` (CI) is unaffected — the integration test is build-tagged so it won't run without MySQL.

## Out of scope (follow-up)

Frontend column/badge + filter UI in `0g-storage-scan-frontend-new`.

Part of #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
