### PR TITLE
feat: provider-level hot/regular node-type tag overlay

### DIFF
--- a/api/storage/api.go
+++ b/api/storage/api.go
@@ -122,6 +122,9 @@ func Register(router *gin.Engine) {
 	rewardsRoute := apiRoute.Group("/rewards")
 	rewardsRoute.GET("", listRewardsHandler)
 
+	storageRoute := apiRoute.Group("/storage")
+	storageRoute.GET("node-types", listNodeTypesHandler)
+
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, ginSwagger.InstanceName("storage")))
 }
 

--- a/api/storage/node_api.go
+++ b/api/storage/node_api.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	scanApi "github.com/0glabs/0g-storage-scan/api"
+	"github.com/Conflux-Chain/go-conflux-util/api"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+)
+
+// NodeTypeInfo is the per-host hot/regular tag returned by GET /api/storage/node-types.
+type NodeTypeInfo struct {
+	IsHot        bool   `json:"isHot"`                  // node is a hot-storage provider
+	IsRegular    bool   `json:"isRegular"`              // node is a regular storage node
+	URL          string `json:"url"`                    // last-seen node url
+	ProviderAddr string `json:"providerAddr,omitempty"` // on-chain provider address (hot only)
+}
+
+type nodeTypeParam struct {
+	NodeType *string `form:"nodeType" binding:"omitempty,oneof=hot regular"`
+}
+
+// listNodeTypes returns a map keyed by node host (hostname or IP, port stripped)
+// of hot/regular tags, mirroring the indexer's getNodeLocations shape so the
+// frontend can merge it by host. Optional ?nodeType=hot|regular filter.
+func listNodeTypes(c *gin.Context) (interface{}, error) {
+	var param nodeTypeParam
+	if err := c.ShouldBind(&param); err != nil {
+		return nil, api.ErrValidation(errors.WithMessage(err, "Invalid node-type param"))
+	}
+
+	nodes, err := db.StorageNodeTypeStore.List(param.NodeType)
+	if err != nil {
+		return nil, scanApi.ErrDatabase(errors.WithMessage(err, "Failed to get node types"))
+	}
+
+	result := make(map[string]NodeTypeInfo, len(nodes))
+	for _, n := range nodes {
+		result[n.Host] = NodeTypeInfo{
+			IsHot:        n.IsHot,
+			IsRegular:    n.IsRegular,
+			URL:          n.URL,
+			ProviderAddr: n.ProviderAddr,
+		}
+	}
+	return result, nil
+}
+
+func listNodeTypesHandler(c *gin.Context) {
+	api.Wrap(listNodeTypes)(c)
+}

--- a/cmd/data_context.go
+++ b/cmd/data_context.go
@@ -64,6 +64,7 @@ var migrationModels = []interface{}{
 	&store.DAClient{},
 	&store.DAClientStat{},
 	&store.RateLimit{},
+	&store.StorageNodeType{},
 }
 
 func MustInitDataContext() DataContext {

--- a/config/config.yml
+++ b/config/config.yml
@@ -42,6 +42,10 @@ eth:
 #  classReconcileInterval: 2m
 #  # Page size when paging GET /files/cached (default 2000)
 #  classPageLimit: 2000
+#  # How often to refresh node hot/regular tags from the indexer + hot router (default 24h)
+#  nodeTypeRefreshInterval: 24h
+#  # Page size when paging the router GET /providers (default 2000)
+#  nodeTypePageLimit: 2000
 
 # storage contracts info configurations
 contract:

--- a/rpc/storage.go
+++ b/rpc/storage.go
@@ -52,6 +52,12 @@ type StorageConfig struct {
 	ClassReconcileInterval time.Duration `default:"2m"`
 	// ClassPageLimit is the page size used when paging GET /files/cached.
 	ClassPageLimit int `default:"2000"`
+
+	// NodeTypeRefreshInterval is how often the worker refreshes node hot/regular
+	// tags from the indexer + hot router. These lists change rarely.
+	NodeTypeRefreshInterval time.Duration `default:"24h"`
+	// NodeTypePageLimit is the page size used when paging the router GET /providers.
+	NodeTypePageLimit int `default:"2000"`
 }
 
 type FileInfoParam struct {
@@ -206,6 +212,104 @@ func ListCachedFiles(cfg StorageConfig, cursor string, limit int) (hashes []stri
 	}
 
 	return result.Hashes, result.NextCursor, nil
+}
+
+type shardedNode struct {
+	URL string `json:"url"`
+}
+
+type shardedNodesRPCResponse struct {
+	Result struct {
+		Trusted    []shardedNode `json:"trusted"`
+		Discovered []shardedNode `json:"discovered"`
+	} `json:"result"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// GetShardedNodes fetches the regular storage network's node URLs (trusted +
+// discovered) from the indexer via JSON-RPC indexer_getShardedNodes (POST to the
+// indexer base URL).
+func GetShardedNodes(cfg StorageConfig) ([]string, error) {
+	url := strings.TrimRight(cfg.Indexer, "/") + "/"
+	reqBody := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "indexer_getShardedNodes",
+		"params":  []interface{}{},
+		"id":      1,
+	}
+
+	client := resty.New()
+	if cfg.RequestTimeout > 0 {
+		client.SetTimeout(cfg.RequestTimeout)
+	}
+
+	var result shardedNodesRPCResponse
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(reqBody).
+		SetResult(&result).
+		Post(url)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "Failed to request indexer getShardedNodes, %s", url)
+	}
+	if resp.IsError() {
+		return nil, errors.Errorf("Failed to request indexer getShardedNodes, %s status %s body %s",
+			url, resp.Status(), resp.String())
+	}
+	if result.Error != nil {
+		return nil, errors.Errorf("indexer getShardedNodes rpc error: %s", result.Error.Message)
+	}
+
+	urls := make([]string, 0, len(result.Result.Trusted)+len(result.Result.Discovered))
+	for _, n := range result.Result.Trusted {
+		urls = append(urls, n.URL)
+	}
+	for _, n := range result.Result.Discovered {
+		urls = append(urls, n.URL)
+	}
+	return urls, nil
+}
+
+// ProviderInfo is one hot-storage provider entry from the router GET /providers.
+type ProviderInfo struct {
+	Address string `json:"address"`
+	URL     string `json:"url"`
+	Active  bool   `json:"active"`
+}
+
+type providersResponse struct {
+	Providers  []ProviderInfo `json:"providers"`
+	NextCursor string         `json:"next_cursor"`
+}
+
+// ListProviders fetches one page of hot-storage providers from the router's
+// GET /providers (keyset-paginated by provider address). Empty returned cursor
+// means there are no more pages.
+func ListProviders(cfg StorageConfig, cursor string, limit int) ([]ProviderInfo, string, error) {
+	url := fmt.Sprintf("%s/providers?limit=%d", strings.TrimRight(cfg.HotRouter, "/"), limit)
+	if cursor != "" {
+		url += "&cursor=" + cursor
+	}
+
+	client := resty.New()
+	if cfg.RequestTimeout > 0 {
+		client.SetTimeout(cfg.RequestTimeout)
+	}
+
+	var result providersResponse
+	resp, err := client.R().SetResult(&result).Get(url)
+	if err != nil {
+		return nil, "", errors.WithMessagef(err, "Failed to request hot router providers, %s", url)
+	}
+	if resp.IsError() {
+		return nil, "", errors.Errorf("Failed to request hot router providers, %s status %s body %s",
+			url, resp.Status(), resp.String())
+	}
+
+	return result.Providers, result.NextCursor, nil
 }
 
 func requestIndexer(url string) ([]byte, error) {

--- a/rpc/storage_test.go
+++ b/rpc/storage_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -70,5 +71,71 @@ func TestListCachedFiles_ErrorStatus(t *testing.T) {
 
 	if _, _, err := ListCachedFiles(StorageConfig{HotRouter: srv.URL}, "", 10); err == nil {
 		t.Fatal("expected an error on a 500 response, got nil")
+	}
+}
+
+func TestGetShardedNodes_ParsesTrustedAndDiscovered(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &req)
+		if req.Method != "indexer_getShardedNodes" {
+			t.Errorf("rpc method = %q, want indexer_getShardedNodes", req.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{"trusted":[{"url":"http://1.1.1.1:1"}],"discovered":[{"url":"http://2.2.2.2:2"}]}}`)
+	}))
+	defer srv.Close()
+
+	urls, err := GetShardedNodes(StorageConfig{Indexer: srv.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(urls) != 2 || urls[0] != "http://1.1.1.1:1" || urls[1] != "http://2.2.2.2:2" {
+		t.Fatalf("urls = %v, want [trusted discovered]", urls)
+	}
+}
+
+func TestGetShardedNodes_RPCError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}`)
+	}))
+	defer srv.Close()
+
+	if _, err := GetShardedNodes(StorageConfig{Indexer: srv.URL}); err == nil {
+		t.Fatal("expected an error on a JSON-RPC error response, got nil")
+	}
+}
+
+func TestListProviders_PagesAndParses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			io.WriteString(w, `{"providers":[{"address":"0xabc","url":"http://h1:1","active":true}],"next_cursor":"0xabc"}`)
+			return
+		}
+		io.WriteString(w, `{"providers":[{"address":"0xdef","url":"http://h2:2","active":false}],"next_cursor":""}`)
+	}))
+	defer srv.Close()
+
+	cfg := StorageConfig{HotRouter: srv.URL}
+
+	p1, next, err := ListProviders(cfg, "", 1)
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if next != "0xabc" || len(p1) != 1 || p1[0].Address != "0xabc" || p1[0].URL != "http://h1:1" || !p1[0].Active {
+		t.Fatalf("page1 = %+v next=%s", p1, next)
+	}
+
+	p2, next2, err := ListProviders(cfg, next, 1)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if next2 != "" || len(p2) != 1 || p2[0].Address != "0xdef" || p2[0].Active {
+		t.Fatalf("page2 = %+v next=%s", p2, next2)
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -52,35 +52,37 @@ type MysqlStore struct {
 	*DAClientStore
 	*DAClientStatStore
 	*RateLimitStore
+	*StorageNodeTypeStore
 }
 
 func MustNewStore(db *gorm.DB, config mysql.Config) *MysqlStore {
 	return &MysqlStore{
-		Store:               mysql.NewStore(db),
-		AddressStore:        newAddressStore(db),
-		BlockStore:          newBlockStore(db),
-		ConfigStore:         newConfigStore(db),
-		SubmitStore:         newSubmitStore(db, config),
-		AddressSubmitStore:  newAddressSubmitStore(db),
-		RewardStore:         newRewardStore(db),
-		RewardStatStore:     newRewardStatStore(db),
-		RewardTopnStatStore: newRewardTopnStatStore(db),
-		AddressRewardStore:  newAddressRewardStore(db),
-		SubmitStatStore:     newSubmitStatStore(db),
-		SubmitTopnStatStore: newSubmitTopnStatStore(db),
-		AddressStatStore:    newAddressStatStore(db),
-		MinerStore:          newMinerStore(db),
-		MinerStatStore:      newMinerStatStore(db),
-		MinerRegisterStore:  newMinerRegisterStore(db),
-		FlowEpochStore:      newFlowEpochStore(db),
-		DASignerStore:       newDASignerStore(db),
-		DASignerStatStore:   newDASignerStatStore(db),
-		DASubmitStore:       newDASubmitStore(db),
-		DARewardStore:       newDARewardStore(db),
-		DASubmitStatStore:   newDASubmitStatStore(db),
-		DAClientStore:       newDAClientStore(db),
-		DAClientStatStore:   newDAClientStatStore(db),
-		RateLimitStore:      newRateLimitStore(db),
+		Store:                mysql.NewStore(db),
+		AddressStore:         newAddressStore(db),
+		BlockStore:           newBlockStore(db),
+		ConfigStore:          newConfigStore(db),
+		SubmitStore:          newSubmitStore(db, config),
+		AddressSubmitStore:   newAddressSubmitStore(db),
+		RewardStore:          newRewardStore(db),
+		RewardStatStore:      newRewardStatStore(db),
+		RewardTopnStatStore:  newRewardTopnStatStore(db),
+		AddressRewardStore:   newAddressRewardStore(db),
+		SubmitStatStore:      newSubmitStatStore(db),
+		SubmitTopnStatStore:  newSubmitTopnStatStore(db),
+		AddressStatStore:     newAddressStatStore(db),
+		MinerStore:           newMinerStore(db),
+		MinerStatStore:       newMinerStatStore(db),
+		MinerRegisterStore:   newMinerRegisterStore(db),
+		FlowEpochStore:       newFlowEpochStore(db),
+		DASignerStore:        newDASignerStore(db),
+		DASignerStatStore:    newDASignerStatStore(db),
+		DASubmitStore:        newDASubmitStore(db),
+		DARewardStore:        newDARewardStore(db),
+		DASubmitStatStore:    newDASubmitStatStore(db),
+		DAClientStore:        newDAClientStore(db),
+		DAClientStatStore:    newDAClientStatStore(db),
+		RateLimitStore:       newRateLimitStore(db),
+		StorageNodeTypeStore: newStorageNodeTypeStore(db),
 	}
 }
 

--- a/store/store_node_type.go
+++ b/store/store_node_type.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"time"
+
+	"github.com/Conflux-Chain/go-conflux-util/store/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// StorageNodeType records whether a storage node (identified by its URL host —
+// hostname or IP, port stripped) is a hot-storage provider, a regular storage
+// node, or both. It is a tag overlay maintained by the RefreshNodeTypes worker;
+// the frontend merges it onto its live node list by host.
+type StorageNodeType struct {
+	Host         string    `gorm:"column:host;size:255;primaryKey"`
+	IsHot        bool      `gorm:"not null;default:false;index"`
+	IsRegular    bool      `gorm:"not null;default:false;index"`
+	URL          string    `gorm:"size:255"` // last-seen full url, for display
+	ProviderAddr string    `gorm:"size:42"`  // on-chain addr, only for hot nodes
+	UpdatedAt    time.Time `gorm:"autoUpdateTime"`
+}
+
+func (StorageNodeType) TableName() string {
+	return "storage_node_types"
+}
+
+type StorageNodeTypeStore struct {
+	*mysql.Store
+}
+
+func newStorageNodeTypeStore(db *gorm.DB) *StorageNodeTypeStore {
+	return &StorageNodeTypeStore{
+		Store: mysql.NewStore(db),
+	}
+}
+
+// UpsertRegular marks the given hosts as regular storage nodes, creating rows as
+// needed and preserving any existing is_hot flag. is_hot/provider_addr are left
+// untouched so the two sources stay independent.
+func (s *StorageNodeTypeStore) UpsertRegular(nodes []StorageNodeType) error {
+	if len(nodes) == 0 {
+		return nil
+	}
+	for i := range nodes {
+		nodes[i].IsRegular = true
+	}
+	return s.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "host"}},
+		DoUpdates: clause.AssignmentColumns([]string{"is_regular", "url", "updated_at"}),
+	}).CreateInBatches(nodes, batchSizeInsert).Error
+}
+
+// UpsertHot marks the given hosts as hot-storage providers, creating rows as needed
+// and preserving any existing is_regular flag.
+func (s *StorageNodeTypeStore) UpsertHot(nodes []StorageNodeType) error {
+	if len(nodes) == 0 {
+		return nil
+	}
+	for i := range nodes {
+		nodes[i].IsHot = true
+	}
+	return s.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "host"}},
+		DoUpdates: clause.AssignmentColumns([]string{"is_hot", "url", "provider_addr", "updated_at"}),
+	}).CreateInBatches(nodes, batchSizeInsert).Error
+}
+
+// HotHosts returns the hosts currently flagged hot (for computing demotions).
+func (s *StorageNodeTypeStore) HotHosts() ([]string, error) {
+	var hosts []string
+	err := s.DB.Model(&StorageNodeType{}).Where("is_hot = ?", true).Pluck("host", &hosts).Error
+	return hosts, err
+}
+
+// RegularHosts returns the hosts currently flagged regular (for computing demotions).
+func (s *StorageNodeTypeStore) RegularHosts() ([]string, error) {
+	var hosts []string
+	err := s.DB.Model(&StorageNodeType{}).Where("is_regular = ?", true).Pluck("host", &hosts).Error
+	return hosts, err
+}
+
+// ClearHot sets is_hot=false for the given hosts (evicted/removed hot providers).
+func (s *StorageNodeTypeStore) ClearHot(hosts []string) error {
+	if len(hosts) == 0 {
+		return nil
+	}
+	return s.DB.Model(&StorageNodeType{}).Where("host IN ?", hosts).Update("is_hot", false).Error
+}
+
+// ClearRegular sets is_regular=false for the given hosts.
+func (s *StorageNodeTypeStore) ClearRegular(hosts []string) error {
+	if len(hosts) == 0 {
+		return nil
+	}
+	return s.DB.Model(&StorageNodeType{}).Where("host IN ?", hosts).Update("is_regular", false).Error
+}
+
+// List returns node-type rows that are hot and/or regular (rows with both flags
+// false are omitted). nodeType filters to "hot" or "regular" when non-nil.
+func (s *StorageNodeTypeStore) List(nodeType *string) ([]StorageNodeType, error) {
+	db := s.DB.Model(&StorageNodeType{})
+	switch {
+	case nodeType != nil && *nodeType == "hot":
+		db = db.Where("is_hot = ?", true)
+	case nodeType != nil && *nodeType == "regular":
+		db = db.Where("is_regular = ?", true)
+	default:
+		db = db.Where("is_hot = ? OR is_regular = ?", true, true)
+	}
+
+	var nodes []StorageNodeType
+	if err := db.Find(&nodes).Error; err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}

--- a/sync/node_type_integration_test.go
+++ b/sync/node_type_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+// MySQL-backed integration test for the node-type reconcile worker. Uses the same
+// throwaway MySQL as storage_class_integration_test.go (mustTestStore helper).
+//
+//	docker run -d --name scan-it-mysql -e MYSQL_ROOT_PASSWORD=root \
+//	    -e MYSQL_DATABASE=scan_it_test -p 3380:3306 mysql:8
+//	go test -tags integration ./sync/ -run TestRefreshNodeTypes -v
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/0glabs/0g-storage-scan/rpc"
+	"github.com/0glabs/0g-storage-scan/store"
+	"github.com/Conflux-Chain/go-conflux-util/health"
+)
+
+// fakeIndexer serves JSON-RPC indexer_getShardedNodes returning the given URLs as
+// trusted nodes.
+func fakeIndexer(urls *[]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nodes := make([]map[string]string, 0, len(*urls))
+		for _, u := range *urls {
+			nodes = append(nodes, map[string]string{"url": u})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1,
+			"result": map[string]interface{}{"trusted": nodes, "discovered": []interface{}{}},
+		})
+	}))
+}
+
+// fakeProviders serves GET /providers returning the given providers in one page.
+func fakeProviders(providers *[]rpc.ProviderInfo) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"providers": *providers, "next_cursor": ""})
+	}))
+}
+
+func nodeTypeMap(t *testing.T, st *store.MysqlStore) map[string]store.StorageNodeType {
+	t.Helper()
+	nodes, err := st.StorageNodeTypeStore.List(nil)
+	if err != nil {
+		t.Fatalf("List node types: %v", err)
+	}
+	m := make(map[string]store.StorageNodeType, len(nodes))
+	for _, n := range nodes {
+		m[n.Host] = n
+	}
+	return m
+}
+
+func assertNode(t *testing.T, m map[string]store.StorageNodeType, host string, isHot, isRegular bool) {
+	t.Helper()
+	n, ok := m[host]
+	if !ok {
+		t.Fatalf("host %s missing from %v", host, m)
+	}
+	if n.IsHot != isHot || n.IsRegular != isRegular {
+		t.Errorf("host %s = {hot:%v regular:%v}, want {hot:%v regular:%v}",
+			host, n.IsHot, n.IsRegular, isHot, isRegular)
+	}
+}
+
+func TestRefreshNodeTypes(t *testing.T) {
+	st := mustTestStore(t)
+	if err := st.DB.AutoMigrate(&store.StorageNodeType{}); err != nil {
+		t.Fatalf("AutoMigrate StorageNodeType: %v", err)
+	}
+	st.DB.Exec("DELETE FROM storage_node_types")
+
+	regular := []string{"http://a.com:1", "http://b.com:2"}
+	hot := []rpc.ProviderInfo{
+		{Address: "0xbbb", URL: "http://b.com:9", Active: true},  // b is BOTH
+		{Address: "0xccc", URL: "http://c.com:9", Active: true},  // c hot-only
+		{Address: "0xddd", URL: "http://d.com:9", Active: false}, // inactive -> ignored
+	}
+	idx := fakeIndexer(&regular)
+	defer idx.Close()
+	rtr := fakeProviders(&hot)
+	defer rtr.Close()
+
+	ss := MustNewStorageSyncer(st, rpc.StorageConfig{
+		Indexer:           idx.URL,
+		HotRouter:         rtr.URL,
+		NodeTypePageLimit: 100,
+		RequestTimeout:    3 * time.Second,
+	}, "", health.TimedCounterConfig{}, nil)
+
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	ctx := context.Background()
+
+	// Round 1: a=regular-only, b=both, c=hot-only, d ignored (inactive).
+	ss.RefreshNodeTypes(ctx, ticker)
+	m := nodeTypeMap(t, st)
+	assertNode(t, m, "a.com", false, true)
+	assertNode(t, m, "b.com", true, true)
+	assertNode(t, m, "c.com", true, false)
+	if _, ok := m["d.com"]; ok {
+		t.Errorf("inactive provider d.com must not be present")
+	}
+
+	// Round 2: b drops from both lists; a regular-only, c hot-only.
+	regular = []string{"http://a.com:1"}
+	hot = []rpc.ProviderInfo{{Address: "0xccc", URL: "http://c.com:9", Active: true}}
+	ss.RefreshNodeTypes(ctx, ticker)
+	m = nodeTypeMap(t, st)
+	assertNode(t, m, "a.com", false, true)
+	assertNode(t, m, "c.com", true, false)
+	if _, ok := m["b.com"]; ok {
+		t.Errorf("b.com should be demoted from both lists and omitted, got %+v", m["b.com"])
+	}
+
+	// Round 3: indexer outage -> regular fetch fails -> must NOT clear regular flags.
+	idx.Close()
+	ss.RefreshNodeTypes(ctx, ticker)
+	m = nodeTypeMap(t, st)
+	assertNode(t, m, "a.com", false, true) // still regular despite the outage
+	assertNode(t, m, "c.com", true, false) // hot source still healthy
+}

--- a/sync/node_type_test.go
+++ b/sync/node_type_test.go
@@ -1,0 +1,19 @@
+package sync
+
+import "testing"
+
+func TestHostFromURL(t *testing.T) {
+	cases := map[string]string{
+		"http://1.2.3.4:5678":    "1.2.3.4",
+		"https://example.com:80": "example.com",
+		"http://example.com":     "example.com",
+		"1.2.3.4:5678":           "1.2.3.4", // scheme-less host:port
+		"example.com":            "example.com",
+		"":                       "",
+	}
+	for in, want := range cases {
+		if got := hostFromURL(in); got != want {
+			t.Errorf("hostFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/sync/storage.go
+++ b/sync/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -221,6 +222,157 @@ func (ss *StorageSyncer) setStorageClassChunked(class string, rootHashes []strin
 		}
 	}
 	return nil
+}
+
+// RefreshNodeTypes tags storage nodes as hot and/or regular by reconciling against
+// two independent sources: the regular indexer's node list (indexer_getShardedNodes)
+// and the hot router's provider list (GET /providers). A single host can be both.
+// Each source is reconciled independently and is NEVER cleared on its own fetch
+// failure (outage safety). These lists change rarely, so it runs daily.
+func (ss *StorageSyncer) RefreshNodeTypes(ctx context.Context, ticker *time.Ticker) {
+	if interrupted(ctx) {
+		return
+	}
+
+	cfg := ss.storageConfig
+	if cfg.Indexer == "" && cfg.HotRouter == "" {
+		ticker.Reset(time.Hour) // nothing to tag
+		return
+	}
+
+	interval := cfg.NodeTypeRefreshInterval
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	limit := cfg.NodeTypePageLimit
+	if limit <= 0 {
+		limit = 2000
+	}
+
+	failed := false
+
+	// Regular source: indexer node list. Skip the reconcile (no clearing) on a fetch error.
+	if cfg.Indexer != "" {
+		if urls, err := rpc.GetShardedNodes(cfg); err != nil {
+			logrus.WithError(err).Warn("Failed to fetch regular node list from indexer; skipping regular node-type reconcile")
+			failed = true
+		} else if err := ss.reconcileRegularNodes(urls); err != nil {
+			logrus.WithError(err).Error("Failed to reconcile regular node types")
+			failed = true
+		}
+	}
+
+	// Hot source: router provider list. Skip the reconcile (no clearing) on a fetch error.
+	if cfg.HotRouter != "" {
+		if providers, err := ss.fetchHotProviders(cfg, limit); err != nil {
+			logrus.WithError(err).Warn("Failed to fetch hot providers from router; skipping hot node-type reconcile")
+			failed = true
+		} else if err := ss.reconcileHotNodes(providers); err != nil {
+			logrus.WithError(err).Error("Failed to reconcile hot node types")
+			failed = true
+		}
+	}
+
+	if failed {
+		ticker.Reset(intervalException)
+		return
+	}
+	ticker.Reset(interval)
+}
+
+func (ss *StorageSyncer) fetchHotProviders(cfg rpc.StorageConfig, limit int) ([]rpc.ProviderInfo, error) {
+	var all []rpc.ProviderInfo
+	cursor := ""
+	for {
+		page, next, err := rpc.ListProviders(cfg, cursor, limit)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return all, nil
+}
+
+func (ss *StorageSyncer) reconcileRegularNodes(urls []string) error {
+	present := make(map[string]string, len(urls)) // host -> representative url
+	for _, u := range urls {
+		if h := hostFromURL(u); h != "" {
+			present[h] = u
+		}
+	}
+
+	nodes := make([]store.StorageNodeType, 0, len(present))
+	for h, u := range present {
+		nodes = append(nodes, store.StorageNodeType{Host: h, URL: u})
+	}
+	if err := ss.db.StorageNodeTypeStore.UpsertRegular(nodes); err != nil {
+		return err
+	}
+
+	current, err := ss.db.StorageNodeTypeStore.RegularHosts()
+	if err != nil {
+		return err
+	}
+	toClear := make([]string, 0)
+	for _, h := range current {
+		if _, ok := present[h]; !ok {
+			toClear = append(toClear, h)
+		}
+	}
+	return ss.db.StorageNodeTypeStore.ClearRegular(toClear)
+}
+
+func (ss *StorageSyncer) reconcileHotNodes(providers []rpc.ProviderInfo) error {
+	present := make(map[string]store.StorageNodeType, len(providers)) // host -> node
+	for _, p := range providers {
+		if !p.Active {
+			continue // inactive providers are not hot
+		}
+		if h := hostFromURL(p.URL); h != "" {
+			present[h] = store.StorageNodeType{Host: h, URL: p.URL, ProviderAddr: p.Address}
+		}
+	}
+
+	nodes := make([]store.StorageNodeType, 0, len(present))
+	for _, n := range present {
+		nodes = append(nodes, n)
+	}
+	if err := ss.db.StorageNodeTypeStore.UpsertHot(nodes); err != nil {
+		return err
+	}
+
+	current, err := ss.db.StorageNodeTypeStore.HotHosts()
+	if err != nil {
+		return err
+	}
+	toClear := make([]string, 0)
+	for _, h := range current {
+		if _, ok := present[h]; !ok {
+			toClear = append(toClear, h)
+		}
+	}
+	return ss.db.StorageNodeTypeStore.ClearHot(toClear)
+}
+
+// hostFromURL extracts the host (hostname or IP, port stripped) from a node URL,
+// matching the frontend's extractIp (URL.hostname). Falls back to scheme-less
+// "host:port" parsing, then to the raw string.
+func hostFromURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	if u, err := url.Parse("//" + raw); err == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	return raw
 }
 
 // checkSyncHeightGaps monitors sync height differences and returns error if gaps exceed 1000 blocks

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -98,6 +98,7 @@ func (s *Syncer) Sync(ctx context.Context, wg *sync.WaitGroup) {
 	go s.storageSyncer.Sync(ctx, s.storageSyncer.LatestFiles)
 	go s.storageSyncer.Sync(ctx, s.storageSyncer.NodeSyncHeight)
 	go s.storageSyncer.Sync(ctx, s.storageSyncer.ReconcileStorageClass)
+	go s.storageSyncer.Sync(ctx, s.storageSyncer.RefreshNodeTypes)
 	go s.patchSyncer.Sync(ctx, s.patchSyncer.L1Txs)
 	go s.patchSyncer.Sync(ctx, s.patchSyncer.MinerAttempts)
 


### PR DESCRIPTION
## What

Adds a provider/node-level **hot vs regular** tag overlay so the explorer's Providers page can label each storage node hot, regular, or both, with a filter.

- **Tag overlay, not a node-list source.** Scan combines two independent sources and serves a per-host tag; the frontend keeps fetching live node data from the indexer and merges this by host (like it already merges `getNodeLocations`).
- **Model**: new `storage_node_types` table keyed by **host** (URL hostname or IP, port stripped — matches the frontend's `extractIp`), with `is_hot` + `is_regular` (a host can be both), `url`, `provider_addr`.
- **Worker** (`RefreshNodeTypes`, daily): sets `is_regular` from the indexer's `indexer_getShardedNodes`, `is_hot` from the router's `GET /providers`; reconciles each source independently and **never clears flags on that source's fetch outage**. Disabled per-source when its URL is unset.
- **rpc**: `GetShardedNodes` (indexer JSON-RPC) + `ListProviders` (router REST, paginated).
- **API**: `GET /api/storage/node-types` → `{ "<host>": {isHot,isRegular,url,providerAddr} }`, `?nodeType=hot|regular` filter; omits hosts with both flags false.

Requires the companion hot-router endpoint: `GET /providers` (0gfoundation/0g-hot-storage PR).

## Design notes

- **Independent lists, may be disjoint** — a hot provider need not be in the indexer list; it still shows via the overlay (`isHot:true, isRegular:false`).
- **Join key = host**; hostnames are not resolved to IPs, so a hostname-vs-IP pair for the same box stays as two entries (acceptable, no dedup).

## Tests

- **Unit**: rpc clients (httptest: JSON-RPC parse + provider paging), `hostFromURL` host/port/scheme cases.
- **Integration** (`go test -tags integration ./sync/`, MySQL-backed): both-flag host, hot-only, regular-only, demotion when a host drops from both lists, and outage-no-clear. **PASS.**
- `go build`/`vet`/`gofmt` clean; default CI `go test ./...` unaffected (integration test is build-tagged).

## Out of scope (follow-up)

Frontend Type column/badge + hot/regular filter on the Providers page.

Part of #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
